### PR TITLE
出退情報一覧更新、印刷機能のバグ修正、他

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,18 @@
 
 ## 構成
 
-[Framework]CakePHP
+[Programming Language]PHP 5.3.20 (or later)
 
-[Database]MySQL
+[Framework]CakePHP 2.7.6
 
-[Web Server]Apache
+[Database]MySQL 5.3 (or later)
+　　※5.6以降の場合は、MySQLのディレクトリ内にあるmy.cnfのsql_modeの「STRICT＿TRANS＿TABLES」設定を削除してください。
+
+[Web Server]Apache 2.2.3 (or later)
 
 [CSS Framework]Bootstrap(Honoka)
 
-[PDF Webkit]WkHtmlToPdf
+[PDF Webkit]WkHtmlToPdf 0.12.3 (or later)
 
 [cakePHP-Plugin]Boostcake,cakePDF
 
@@ -29,7 +32,7 @@ Apache
 
 MySQL
 
-WkHtmlToPdf（+日本語フォント）
+WkHtmlToPdf（+IPA日本語フォント）
 
 
 ##設定ファイル変更

--- a/app/Controller/EntranceDatasController.php
+++ b/app/Controller/EntranceDatasController.php
@@ -3,8 +3,8 @@ App::uses('AppController', 'Controller');
 
 class EntranceDatasController extends AppController {
     public $scaffold;
-    
-    /* 
+
+    /*
      * アクション名：beforeFilter
      * 概要：各アクション実行前に行う処理
      */
@@ -13,43 +13,43 @@ class EntranceDatasController extends AppController {
         $this->Auth->allow('index','entrance','leave');
         $this->set('auth',$this->Auth);
     }
-    
-    /* 
+
+    /*
      * アクション名：index
      * 概要：TOP画面の処理
      */
     public function index() {
         //ページ名
-        $this->set('title_for_layout', 'TOP');   
+        $this->set('title_for_layout', 'TOP');
 
     }
-    
-    /* 
+
+    /*
      * アクション名：entrance
      * 概要：出社情報登録画面の処理
      */
     public function entrance() {
-        
+
         //ページ名
-        $this->set('title_for_layout', '出社情報登録');   
- 
+        $this->set('title_for_layout', '出社情報登録');
+
         //当日の日付を取得
         $today = date("Y-m-d");
-        
+
         //変数の宣言
         $selectedDay = null;
         $enttime = '';
         $errFlg = '0';
-        
+
         //submit処理の分岐
         if ($this->request->is('post') || $this->request->is('put')) {
             if(!empty($this->data)){
                 //前画面で選択された日付を変数に格納
                 $selectedDay = $this->request->data('EntranceData.RECORD_DATE');
-                
+
                 //保存ボタンの場合の処理("True"の場合はif以下の文、"False"の場合はelse以下の文を実行)
                 if(isset($this->request->data['save'])){
-                    
+
                     //退社データのバリデーションを行わないよう、除外する
                     $this->EntranceData->validator()->remove('LEAVE_NAME');
                     $this->EntranceData->validator()->remove('LEAVE_TIME');
@@ -63,7 +63,7 @@ class EntranceDatasController extends AppController {
                     $this->EntranceData->validator()->remove('LEAVE_LIGHT');
                     $this->EntranceData->validator()->remove('LEAVE_KEY');
                     $this->EntranceData->validator()->remove('LEAVE_COMMENT');
-                    
+
                     //データの保存処理を実行
                     if ($this->EntranceData->saveAll($this->request->data)){
                         //完了メッセージを表示
@@ -71,8 +71,8 @@ class EntranceDatasController extends AppController {
                             'plugin' => 'BoostCake',
                             'class' => 'alert-success'
                         ));
-                        
-                        
+
+
                     } else {
                         //バリデーションエラーの場合
                         //エラーフラグを1に設定
@@ -83,29 +83,29 @@ class EntranceDatasController extends AppController {
                             'plugin' => 'BoostCake',
                             'class' => 'alert-danger'
                         ));
-                        
+
                     }
                 }
             }
-        
-        //上記のどれにも当てはまらない場合は下記のelse文が実行される   
+
+        //上記のどれにも当てはまらない場合は下記のelse文が実行される
         }else {
-            
+
             //TOP画面から遷移してきた場合は当日日付を取得
             $selectedDay = $today;
-        
+
         }
-        
+
         //管理者チェックの有無を確認し、チェック有の場合は編集不可にする
         $editFlg = $this->_checkManagerCheck($selectedDay);
 
         //本番サーバーの場合、アクセス元がJCS本社でなければ編集不可とする
         $editFlg = $this->_checkServerIP();
-        
+
         //エラーフラグが0の場合(バリデーションエラーが発生した場合、エラーフラグは1になる)
         //(バリデーションエラーの場合は、DBのデータではなくリクエストデータを表示させるため、以下のDB読み込みを行わない)
         If ($errFlg == '0'){
-            
+
             //特定の日付($selectedDay)を条件に、ENTRANCE_DATASテーブルの情報を検索する
             //検索した結果、データが存在する場合は「request->data」に値を入れて、ビュー側で表示できるようにする
             If(!$this->request->data = $this->EntranceData->findByRecord_date($selectedDay)) {
@@ -113,52 +113,52 @@ class EntranceDatasController extends AppController {
                 $enttime = ENT_TIME;
             }
         }
-        
+
         //7日分(当日～当日マイナス6日分)の日付を取得する(共通関数を使用)
-        $options = $this->Common->getWeek(); 
-        
+        $options = $this->Common->getWeek();
+
         //ビューで使用する変数(week)に上記で日付を格納した変数($options)をセットする
         $this->set('week', $options);
-        
+
         //ビューで使用する変数をセットする
-        $this->set('selectedDay', $selectedDay);   
-        $this->set('enttime', $enttime);   
+        $this->set('selectedDay', $selectedDay);
+        $this->set('enttime', $enttime);
         $this->set('editFlg', $editFlg);
-    
+
     }
-    
-    
-    /* 
+
+
+    /*
      * アクション名：leave
      * 概要：退社情報登録画面の処理
      */
     public function leave() {
-        
+
         //ページ名
-        $this->set('title_for_layout', '退社情報登録');   
+        $this->set('title_for_layout', '退社情報登録');
 
         //当日の日付を取得
         $today = date("Y-m-d");
-        
+
         //変数の宣言
         $selectedDay = null;
         $leavetime = '';
         $errFlg = '0';
-        
+
         //submit処理の分岐
         if ($this->request->is('post') || $this->request->is('put')) {
             if(!empty($this->data)){
                 //前画面で選択された日付を変数に格納
                 $selectedDay = $this->request->data('EntranceData.RECORD_DATE');
-                
+
                 //保存ボタンの場合の処理("True"の場合はif以下の文、"False"の場合はelse以下の文を実行)
                 if(isset($this->request->data['save'])){
-                    
+
                     //出社データのバリデーションチェックは行わないため、除外
                     $this->EntranceData->validator()->remove('ENT_NAME');
                     $this->EntranceData->validator()->remove('ENT_TIME');
-                    $this->EntranceData->validator()->remove('ENT_COMMENT');               
-                    
+                    $this->EntranceData->validator()->remove('ENT_COMMENT');
+
                     //リクエストデータ「使用した鍵」の値を変数に格納
                     $used_key = $this->request->data('EntranceData.LEAVE_KEY');
                     //上の変数が「その他」以外の場合
@@ -166,14 +166,14 @@ class EntranceDatasController extends AppController {
                         //「自分用」または「最終退室用」を選択した場合は「その他」のテキストボックスの入力チェックを行わない
                         $this->EntranceData->validator()->remove('LEAVE_COMMENT');
                     }
-                    
+
                     //データの保存処理を実行
                     if ($this->EntranceData->saveAll($this->request->data)){
                         $this->Session->setFlash(__('データを保存しました。'), 'alert', array(
                             'plugin' => 'BoostCake',
                             'class' => 'alert-success'
-                        ));    
-                    } else {    
+                        ));
+                    } else {
                         //バリデーションエラーの場合はエラーフラグを1に設定
                         $errFlg = '1';
                         //エラーメッセージを表示
@@ -181,24 +181,24 @@ class EntranceDatasController extends AppController {
                             'plugin' => 'BoostCake',
                             'class' => 'alert-danger'
                         ));
-                    }    
+                    }
                 }
             }
-        
-        //上記のどれにも当てはまらない場合は下記のelse文が実行される   
+
+        //上記のどれにも当てはまらない場合は下記のelse文が実行される
         }else {
-            
+
             //TOP画面から遷移してきた場合は当日日付を取得
             $selectedDay = $today;
-        
+
         }
-        
+
         //管理者チェックの有無を確認し、チェック済みの場合は編集不可とする
         $editFlg = $this->_checkManagerCheck($selectedDay);
 
         //本番サーバーの場合、アクセス元がJCS本社でなければ編集不可とする
         $editFlg = $this->_checkServerIP();
-        
+
         //エラーフラグが0の場合(バリデーションエラーが発生した場合、エラーフラグは1になる)
         //(バリデーションエラーの場合は、DBのデータではなくリクエストデータを表示させるため、以下のDB読み込みを行わない)
         If ($errFlg == '0'){
@@ -209,28 +209,28 @@ class EntranceDatasController extends AppController {
                 $leavetime = LEAVE_TIME;
             }
         }
-        
+
         //7日分(当日～当日マイナス6日分)の日付を取得する(共通関数を使用)
         $options = $this->Common->getWeek();
-        
+
         //ビューで使用する変数(week)に上記で日付を格納した変数($options)をセットする
         $this->set('week', $options);
-        
+
         //ビューで使用する変数をセットする
-        $this->set('selectedDay', $selectedDay);   
+        $this->set('selectedDay', $selectedDay);
         $this->set('leavetime', $leavetime);
         $this->set('editFlg', $editFlg);
-        
+
     }
-    
-    
+
+
     /* 関数名：_checkManagerCheck
      * 概要：特定の日付の、管理者チェックが完了しているかどうかを確認する
      * 引数：$selectedDay-検索対象の日付
      * 戻り値：True/False
      */
     public function _checkManagerCheck($selectedDay) {
-        
+
         //特定の日付($selectedDay)の情報が入力されていて、
         //なおかつ管理者チェックが完了している("MANAGER_CHECK"が"1")という条件を変数($opt)に設定
         $opt = array("AND" => array(
@@ -238,9 +238,9 @@ class EntranceDatasController extends AppController {
             "EntranceData.MANAGER_CHECK" => '1'
             )
         );
-        
+
         //上記で設定した条件で、DB検索
-        If($this->EntranceData->find('all',array('conditions' => $opt))) { 
+        If($this->EntranceData->find('all',array('conditions' => $opt))) {
             //データが存在する場合（管理者チェックが完了していれば）チェックが完了していれば情報の編集は不可能
             $managerCheck = true;
 
@@ -249,17 +249,17 @@ class EntranceDatasController extends AppController {
                 'plugin' => 'BoostCake',
                 'class' => 'alert-info'
             ));
-            
+
         } else {
             //データが存在しない場合(管理者チェックが完了していない場合)チェックが完了していない場合は情報の編集が可能
             $managerCheck = false;
         }
-        
+
         return $managerCheck;
-    
+
     }
-    
-    
+
+
     /* 関数名：_checkServerIP
      * 概要：本番サーバーの場合、アクセス元がJCS本社でなければ編集不可とする
      * 引数：なし
@@ -268,7 +268,7 @@ class EntranceDatasController extends AppController {
     public function _checkServerIP() {
 
         $editFlg = false;
-        
+
         If ($_SERVER['SERVER_NAME'] == HONBAN_URL) {
             if (!($_SERVER["REMOTE_ADDR"] == JCS_IP || $_SERVER["REMOTE_ADDR"] == JCS_IP2 )) {
                 $editFlg = true;
@@ -278,12 +278,12 @@ class EntranceDatasController extends AppController {
                 ));
             }
         }
-        
+
         return $editFlg;
-    
+
     }
-    
-    
+
+
     /*
      * アクション名：detail
      * 概要：詳細画面の処理
@@ -296,22 +296,22 @@ class EntranceDatasController extends AppController {
 
         //当日の日付を取得
         $today = date("Y-m-d");
-        
+
         $selectedDay = $today;
         $enttime = '';
         $leavetime = '';
         $errFlg = '0';
         $select_btn ='1';
-        
+
         //submit処理の分岐
         if ($this->request->is('post') || $this->request->is('put')) {
             if(!empty($this->data)){
                 //前画面で選択された日付を変数に格納
                 $selectedDay = $this->request->data('EntranceData.RECORD_DATE');
-                
+
                 //保存ボタンの場合の処理("True"の場合はif以下の文、"False"の場合はelse以下の文を実行)
                 if(isset($this->request->data['save'])){
-                    
+
                     //リクエストデータ「使用した鍵」の値を変数に格納
                     $used_key = $this->request->data('EntranceData.LEAVE_KEY');
                     //上の変数が「その他」以外の場合
@@ -319,7 +319,7 @@ class EntranceDatasController extends AppController {
                         //「自分用」または「最終退室用」を選択した場合は「その他」のテキストボックスの入力チェックを行わない
                         $this->EntranceData->validator()->remove('LEAVE_COMMENT');
                     }
-                    
+
                     //データの保存処理を実行
                     if ($this->EntranceData->saveAll($this->request->data)){
                         //保存したときのメッセージ
@@ -327,13 +327,13 @@ class EntranceDatasController extends AppController {
                             'plugin' => 'BoostCake',
                             'class' => 'alert-success'
                         ));
-                        
+
                         //保存処理実行後のリンク「一覧へ」に前画面で選択されていたラジオボタンの値を渡す
                         if(!empty($this->request->query['select_btn'])){
                             //選択したラジオボタンの値を取得する(詳細⇒一覧へ遷移‐URLで渡された値を取得)
                             $select_btn = $this->request->query['select_btn'];
                         }
-                    
+
                     } else {
                         //バリデーションエラーの場合はエラーフラグを1に設定
                         $errFlg = '1';
@@ -343,35 +343,35 @@ class EntranceDatasController extends AppController {
                             'class' => 'alert-danger'
                         ));
                     }
-                
+
                 }
             }
-        
+
         //getの場合(詳細画面から遷移してきた場合)の処理
         } else if ($this->request->is('get')) {
             if(!empty($this->request->query['selectedDay'])){
                 //選択した日付を取得する(詳細画面⇒一覧画面へ遷移‐URLで渡された値を取得)
                 $selectedDay = $this->request->query['selectedDay'];
             }
-            
+
             if(!empty($this->request->query['select_btn'])){
                 //選択したラジオボタンの値を取得する(詳細画面⇒一覧画面へ遷移‐URLで渡された値を取得)
                 $select_btn = $this->request->query['select_btn'];
             }
-        
+
         }
-        
+
         //エラーフラグが0の場合(バリデーションエラーが発生した場合、エラーフラグは1になる)
         //(バリデーションエラーの場合は、DBのデータではなくリクエストデータを表示させるため、以下のDB読み込みを行わない)
         If ($errFlg == '0'){
-            
+
             //特定の日付($selectedDay)を条件に、ENTRANCE_DATASテーブルの情報を検索する
             //検索した結果、データが存在する場合は「request->data」に値を入れて、ビュー側で使用できるようにする
             If(!$this->request->data = $this->EntranceData->findByRecord_date($selectedDay)) {
                 //検索した結果、データが見つからない場合、出社時間の初期値を設定
                 $enttime = ENT_TIME;
             }
-            
+
             //特定の日付($selectedDay)を条件に、ENTRANCE_DATASテーブルの情報を検索する
             //検索した結果、データが存在する場合は「request->data」に値を入れて、ビュー側で使えるようにする
             If(!$this->request->data = $this->EntranceData->findByRecord_date($selectedDay)) {
@@ -379,42 +379,42 @@ class EntranceDatasController extends AppController {
                 $leavetime = LEAVE_TIME;
             }
         }
-        
-        
+
+
         //ビューで使用する変数をセットする
         $this->set('selectedDay', $selectedDay);
         $this->set('enttime', $enttime);
         $this->set('leavetime', $leavetime);
         $this->set('select_btn', $select_btn);
-        
+
         //$displaydateに詳細画面で表示する日付を設定、view-set
         $displaydate = date("Y年m月d日", strtotime($selectedDay));
         $this->set('displaydate', $displaydate);
-        
+
         //詳細画面で表示する曜日を設定、view-set
         $wday = Configure::read('wday');
         $w = $wday[date("w", strtotime($selectedDay))];
         $this->set('w', $w);
-        
+
         //詳細画面⇒一覧画面へ遷移する場合の表示($selectedDayで年や月を個別で取得出来る)
         $y = date("Y", strtotime($selectedDay));
         $m = date("m", strtotime($selectedDay));
-        
+
         //view-set[選択された年月]
         $this->set('y', $y);
         $this->set('m', $m);
-        
+
         //詳細画面にて前日の情報を取得、view-set[前日の情報]
         $previousday  = date('Y-m-d', strtotime('-1 day', strtotime($selectedDay)));
         $this->set('previousday', $previousday);
-        
+
         //詳細画面にて翌日の情報を取得、view-set[翌日の情報]
         $nextday  = date('Y-m-d', strtotime('+1 day', strtotime($selectedDay)));
         $this->set('nextday', $nextday);
-    
+
     }
-    
-    
+
+
     /*
      * アクション名：adminlist
      * 概要：一覧画面の処理
@@ -423,73 +423,73 @@ class EntranceDatasController extends AppController {
 
         //ページ名
         $this->set('title_for_layout', '出退情報一覧');
-        
+
         //当年・当月を取得
         $y = date('Y');
         $m = date('m');
-        
+
         //変数の設定
         $wday = Configure::read('wday');
         $resultset = '';
         $select_btn ='1';
-        
+
         //submit処理の分岐
         if ($this->request->is('post') || $this->request->is('put')) {
-            
+
             if(!empty($this->data)){
                 //前画面で選択された年月、ラジオボタンを変数に格納(一覧⇒詳細へ)
                 $y = $this->request->data('EntranceData.select1');
                 $m = $this->request->data('EntranceData.select2');
                 $select_btn = $this->request->data('EntranceData.selectbutton');
             }
-        
+
         //上記のどれにも当てはまらない場合は下記のelse文が実行される
         } else if ($this->request->is('get')) {
-            
+
             //前画面で表示されていた年を変数に格納
             if(!empty($this->request->query['year'])){
-                $y = $this->request->query['year'];   
+                $y = $this->request->query['year'];
             }
-            
+
             //前画面で表示されていた月を変数に格納
             if(!empty($this->request->query['month'])){
                 $m = $this->request->query['month'];
             }
-            
+
             //前画面で選択されたラジオボタンの値を格納
             if(!empty($this->request->query['select_btn'])){
                 $select_btn = $this->request->query['select_btn'];
             }
-        
+
         }
-        
+
         //3年分(当年～当年マイナス2年分)の日付を取得する(共通関数を使用)
         $years = $this->Common->getYear();
-        
+
         //ビューで使用する変数(year)に$yearsをセットする
         $this->set('year', $years);
-        
+
         //view-set
         $this->set("thisyear", $y);
         $this->set("thismonth", $m);
         $this->set("select_btn", $select_btn);
-        
+
         //末日を取得
         $lastday = date("t", mktime(0,0,0,$m,1,$y));
-        
+
         //1ヶ月分のデータを表示するループ処理
         for($d=1;($d <= $lastday);$d++){
-            
+
             //表示フラグ(表示する場合は"0"、表示しない場合は"1")
             //ループ処理を行うので最後の処理が完了後、$hyoujiFlgは初期化される
-            $hyoujiFlg = '0';       
-            
+            $hyoujiFlg = '0';
+
             //$timestampに対象の日付を取得
             $timestamp = mktime(0,0,0,$m,$d,$y);
-            
+
             //$wに対象の曜日を取得
             $w = $wday[date("w", $timestamp)];
-            
+
             //入力状況を確認する為の検索条件を変数に格納
             $input_check = array(
                 'RECORD_DATE' => date("Y-m-d", $timestamp)
@@ -504,34 +504,35 @@ class EntranceDatasController extends AppController {
                 ,'LEAVE_SEAIRCON' => '1'
                 ,'LEAVE_LIGHT' => '1'
             );
-            
+
             //上記で設定した条件で検索を行う
             if ($this->EntranceData->hasAny($input_check)) {
             //条件に合致するデータが存在する場合、入力済みとみなし、変数($input_ck)に結果のメッセージを格納
                 $input_ck = '入力済';
-                
+
                 if($select_btn == "2"){
                     //表示フラグを1（非表示）に設定
-                    $hyoujiFlg = '1';       
-                }                
-            
+                    $hyoujiFlg = '1';
+                }
+
             } else {
                 $input_ck = '';
             }
-            
+
             //変数($mng_check)に対象日の「MANAGER_CHECK」を検索して格納
-            $mng_check = $this->EntranceData->findByRecord_date(date("Y-m-d", $timestamp),'MANAGER_CHECK');
-            
+            // $mng_check = $this->EntranceData->findByRecord_date(date("Y-m-d", $timestamp),'MANAGER_CHECK');
+            $result = $this->EntranceData->findByRecord_date(date("Y-m-d", $timestamp));
+
             //上記で検索した値を変数($check)に格納
-            $check = Hash::get($mng_check, 'EntranceData.MANAGER_CHECK'); 
-            
+            $check = Hash::get($result, 'EntranceData.MANAGER_CHECK');
+
             //取得結果が1（管理者チェック済）の場合は変数($manager_ck)に結果のメッセージを格納
             if ($check == 1){
-                $manager_ck = "確認済"; 
-                
+                $manager_ck = "確認済";
+
                 if($select_btn == "3"){
                 //表示フラグを1（非表示）に設定
-                    $hyoujiFlg = '1';     
+                    $hyoujiFlg = '1';
                 }
             } else {
                 $manager_ck = "";
@@ -540,18 +541,36 @@ class EntranceDatasController extends AppController {
             //土日の場合は背景色を変更
             $tdcolor = '';
             if ($w == '土' || $w == '日'){$tdcolor = 'class = "active"';}
-            
+
             if ($hyoujiFlg == "0") {
-                 //一覧⇒詳細へ遷移する場合の表示("～EntranceDatas/detail?selectedDay=20XX-XX-XX"となる)
-                 $resultset = $resultset ."<tr><td ". $tdcolor ."><a href='../EntranceDatas/detail?selectedDay="
-                    .date("Y-m-d", $timestamp) ."&select_btn="."$select_btn'>".date("Y/m/d", $timestamp) ."({$w})" 
-                    ."</a></td><td ". $tdcolor .">$input_ck</td><td ". $tdcolor .">$manager_ck</td></tr>\n";
+
+                // 出退勤者／時間の設定
+                $ent = $leave = "";
+                if ( !empty(Hash::get($result, 'EntranceData.ENT_NAME'))
+                    && !empty(Hash::get($result, 'EntranceData.ENT_TIME')) ) {
+                    $ent = Hash::get($result, 'EntranceData.ENT_NAME')
+                        ." ( ".date('G:i', strtotime(Hash::get($result, 'EntranceData.ENT_TIME')))." )";
+                }
+                if ( !empty(Hash::get($result, 'EntranceData.LEAVE_NAME'))
+                    && !empty(Hash::get($result, 'EntranceData.LEAVE_TIME')) ) {
+                    $leave = Hash::get($result, 'EntranceData.LEAVE_NAME')
+                        ." ( ".date('G:i', strtotime(Hash::get($result, 'EntranceData.LEAVE_TIME')))." )";
+                }
+
+                //一覧⇒詳細へ遷移する場合の表示("～EntranceDatas/detail?selectedDay=20XX-XX-XX"となる)
+                $resultset =
+                     "$resultset<tr><td $tdcolor><a href='../EntranceDatas/detail?selectedDay=".date("Y-m-d", $timestamp)
+                         ."&select_btn=$select_btn'>".date("Y/m/d", $timestamp) ."({$w})</a></td>"
+                    ."<td $tdcolor>$ent</td>"
+                    ."<td $tdcolor>$leave</td>"
+                    ."<td $tdcolor>$input_ck</td>"
+                    ."<td $tdcolor>$manager_ck</td></tr>\n";
             }
-        
-        }     
-        
+
+        }
+
         //view-set
-        $this->set("resultset", $resultset);
+        $this->set("resultset", $resultset."\n");
     }
 
 }

--- a/app/Model/EntranceData.php
+++ b/app/Model/EntranceData.php
@@ -2,10 +2,22 @@
 App::uses('AppModel', 'Model');
 
 class EntranceData extends AppModel {
-    
     public $useTable = 'entrance_datas';
     public $primaryKey = 'ID';
-    
+
+    // バリデーション、保存前に前後の全半角空白を除去するフィールド
+    static $trimItems = array("ENT_NAME", "LEAVE_NAME");
+
+    // バリデーション実行前のコールバックメソッド
+    public function beforeValidate($options = array()) {
+        // 前後空白を除去する
+        foreach ($this->data[$this->name] as $key => &$value) {
+            if ( in_array($key, EntranceData::$trimItems) ) {
+                $value = trim(mb_convert_kana($value, "s"));
+            }
+        }
+    }
+
     //出社・退社情報入力画面のバリデーション
     public $validate = array(
         'ENT_NAME'=>array(
@@ -29,7 +41,7 @@ class EntranceData extends AppModel {
             'rule' => array('maxLength',400),
             'required' =>true,
             'message' =>'400文字以内で入力してください。'
-        ),        
+        ),
         'LEAVE_NAME'=>array(
             'LEAVE_NAMERule-1'=>array(
                 'rule' => 'notBlank',
@@ -62,42 +74,42 @@ class EntranceData extends AppModel {
         'LEAVE_CLEAR' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_WINDOW' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_PRINTER' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_HUMID' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_FAX' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_AIRCON' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_SEAIRCON' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_LIGHT' => array(
             'rule'     => array('comparison', '!=', 0),
             'required' => true,
-            'message' => '必ず選択してください。'      
+            'message' => '必ず選択してください。'
         ),
         'LEAVE_KEY'=>array(
             'rule' => 'notBlank',

--- a/app/View/EntranceDatas/adminlist.ctp
+++ b/app/View/EntranceDatas/adminlist.ctp
@@ -3,12 +3,12 @@
 </div>
 
 <?php
-    
+
     /**
      * FormHelperの宣言
      */
     echo $this->Form->create('EntranceData');
-    
+
     /**
      * 表示項目名：なし
      * DB項目名　：ID
@@ -16,22 +16,22 @@
      * 初期表示値：なし
      */
     echo $this->Form->input('ID');
-    
-    
+
+
     /**
      * 表示項目名：なし
      * DB項目名　：なし
      * 表示する値：3年分のデータ
      * 初期表示値：$thisyear
-     */  
+     */
     echo '<p>';
     echo $this->Form->select('select1', array($year), array(
         'value' => $thisyear
-        ,'empty' => false 
+        ,'empty' => false
         ,'class'=> 'form-control'
     ));
     echo '</p>';
-    
+
     /**
      * 表示項目名：なし
      * DB項目名　：なし
@@ -58,7 +58,7 @@
             ,'class'=> 'form-control'
     ));
     echo '</p>';
-    
+
     /**
      * 表示項目名：全ての日付を表示、入力されていない日付のみ表示、管理者確認がされていない日付のみ表示
      * DB項目名　：なし
@@ -72,8 +72,8 @@
     echo $this->Form->radio('selectbutton', $options, $attributes);
     echo '</div>';
     echo '</pre>';
-    
-    
+
+
     /**
      * 表示項目名：表示
      * DB項目名　：なし
@@ -83,25 +83,27 @@
     echo '<p>';
     echo $this->Form->button('<span class="glyphicon glyphicon-calendar"></span>　表示　', array('name' => 'display', 'class' => 'btn btn-primary btn-block'));
     echo '</p>';
-    
-    
+
+
     /**
      * 結果一覧の表示
      */
     echo "<div style='margin-top:30px;text-align:center;'>";
     echo "<table class='table table-bordered table-hover'>";
     echo "<tr>";
-    echo "<th class='active'><div class='text-center''>日付</div></th>";
-    echo "<th class='active'><div class='text-center''>入力状況</div></th>";
-    echo "<th class='active'><div class='text-center''>確認状況</div></th>";
+    echo "<th class='active'><div class='text-center'>日付</div></th>";
+    echo "<th class='active'><div class='text-center'>出勤者（出勤時間）</div></th>";
+    echo "<th class='active'><div class='text-center'>退出者（退出時間）</div></th>";
+    echo "<th class='active'><div class='text-center'>入力状況</div></th>";
+    echo "<th class='active'><div class='text-center'>確認状況</div></th>";
     echo "</tr>";
     echo $resultset;
     echo "</table>";
-    
-    
+
+
     /**
      * FormHelperの終了
      */
-    echo $this->Form->end(); 
+    echo $this->Form->end();
 
 ?>

--- a/app/View/EntranceDatas/detail.ctp
+++ b/app/View/EntranceDatas/detail.ctp
@@ -12,17 +12,17 @@
 <div class="well well-sm">
 <?php echo $this->html->link('一覧画面に戻る', array('action'=>'adminlist','?'=>array('year'=>$y,'&','month'=>$m,'&','select_btn'=>$select_btn))); ?>
 　｜　
-<?php echo $this->html->link('この画面を印刷する', array('action'=>'detail.pdf')); ?>
+<?php echo $this->html->link('この画面を印刷する', array('action'=>'detail.pdf','?'=>array('selectedDay'=>$selectedDay))); ?>
 </div>
 
 <?php echo $this->Session->flash(); ?>
 
 <?php
-        
+
     /**
      * FormHelperの宣言
      */
-    echo $this->Form->create('EntranceData', 
+    echo $this->Form->create('EntranceData',
         array(
             'name'=>'usedKey'
             ,'inputDefaults' => array(
@@ -30,7 +30,7 @@
             )
         )
     );
-    
+
     /**
      * 表示項目名：なし
      * DB項目名　：ID
@@ -38,7 +38,7 @@
      * 初期表示値：なし
      */
     echo $this->Form->input('ID');
-    
+
     /**
      * 表示項目名：なし
      * DB項目名　：RECORD_DATE
@@ -58,15 +58,15 @@
      */
     echo '<p>';
     echo $this->html->link('≪', array('action'=>'detail','?'=>array('selectedDay'=>$previousday,'&','select_btn'=>$select_btn)));
-    echo '&nbsp;&nbsp;';    
+    echo '&nbsp;&nbsp;';
     echo $displaydate."(".$w.")";
-    echo '&nbsp;&nbsp;';    
+    echo '&nbsp;&nbsp;';
     echo $this->html->link('≫', array('action'=>'detail','?'=>array('selectedDay'=>$nextday,'&','select_btn'=>$select_btn)));
-    echo '</p>';    
-    
-?>    
+    echo '</p>';
+
+?>
 </div>
-<?php    
+<?php
     /**
      * 表示項目名：出社時間
      * DB項目名　：ENT_TIME
@@ -78,12 +78,12 @@
     echo $this->Form->input('ENT_TIME', array(
         'type' => 'time'
         ,'label' => '出社時間'
-        ,'timeFormat' => '24' 
+        ,'timeFormat' => '24'
         ,'selected' => $enttime
     ));
     echo '</p>';
     echo '</div>';
-    
+
     /**
      * 表示項目名：最初に出社した人
      * DB項目名　：ENT_NAME
@@ -92,14 +92,14 @@
      */
     echo '<p>';
     echo $this->Form->input('ENT_NAME', array(
-        'type' => 'textbox' 
+        'type' => 'textbox'
         ,'label' => '最初に出社した人：'
         ,'required' => false
         ,'default' => ''
         ,'maxLength' => 40
     ));
     echo '</p>';
-    
+
     /**
      * 表示項目名：コメント(気がついたこと)
      * DB項目名　：ENT_COMMENT
@@ -108,14 +108,14 @@
      */
     echo '<p>';
     echo $this->Form->input('ENT_COMMENT', array(
-        'type'=>'textarea', 
-        'label'=>'コメント(気がついたこと)：' 
+        'type'=>'textarea',
+        'label'=>'コメント(気がついたこと)：'
         ,'default' => ''
         ,'maxLength' => 400
         ,'required' => false
     ));
     echo '</p>';
-    
+
     /**
      * 表示項目名：退社時間
      * DB項目名　：LEAVE_TIME
@@ -127,12 +127,12 @@
     echo $this->Form->input('LEAVE_TIME', array(
         'type' => 'time'
         ,'label' => '退社時間'
-        ,'timeFormat' => '24' 
+        ,'timeFormat' => '24'
         ,'selected' => $leavetime
     ));
     echo '</p>';
     echo '</div>';
-    
+
     /**
      * 表示項目名：最後に退社した人
      * DB項目名　：LEAVE_NAME
@@ -141,128 +141,128 @@
      */
     echo '<p>';
     echo $this->Form->input('LEAVE_NAME', array(
-        'type' => 'textbox' 
-        ,'label' => '最後に退社した人' 
-        ,'required' => false 
+        'type' => 'textbox'
+        ,'label' => '最後に退社した人'
+        ,'required' => false
         ,'default' => ''
         ,'maxLength' => 40
     ));
-    echo '</p>'; 
-    
+    echo '</p>';
+
     echo '<p>';
     echo '<label>チェック項目&nbsp;&nbsp;</label>';
-    
+
     echo $this->Form->button('全て選択', array(
         'type' => 'button'
        ,'id' => 'all_check'
        ,'class' => 'btn btn-primary '
     ));
-    echo '</p>'; 
-    
+    echo '</p>';
+
     /**
      * 表示項目名：クリアデスク
      * DB項目名　：LEAVE_CLEAR
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_CLEAR', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_CLEAR', array(
+        'type' => 'checkbox'
         ,'label' => 'クリアデスク'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：室内の窓を施錠
      * DB項目名　：LEAVE_WINDOW
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_WINDOW', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_WINDOW', array(
+        'type' => 'checkbox'
         ,'label' => '室内の窓を施錠'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：プリンタの電源OFF
      * DB項目名　：LEAVE_PRINTER
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_PRINTER', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_PRINTER', array(
+        'type' => 'checkbox'
         ,'label' => 'プリンタの電源OFF'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：加湿器(冬期)電源OFF
      * DB項目名　：LEAVE_HUMID
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_HUMID', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_HUMID', array(
+        'type' => 'checkbox'
         ,'label' => '加湿器(冬期)電源OFF'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：FAX・コピー確認(紙は残っていないか)
      * DB項目名　：LEAVE_FAX
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_FAX', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_FAX', array(
+        'type' => 'checkbox'
         ,'label' => 'FAX・コピー確認(紙は残っていないか)'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：エアコンの電源OFF
      * DB項目名　：LEAVE_AIRCON
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_AIRCON', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_AIRCON', array(
+        'type' => 'checkbox'
         ,'label' => 'エアコンの電源OFF'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：サーバー室のエアコンの電源ON
      * DB項目名　：LEAVE_SEAIRCON
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_SEAIRCON', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_SEAIRCON', array(
+        'type' => 'checkbox'
         ,'label' => 'サーバー室のエアコンの電源ON'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：全室内の消灯
      * DB項目名　：LEAVE_LIGHT
      * 表示する値：チェックボックス
      * 初期表示値：空白
      */
-    echo $this->Form->input('LEAVE_LIGHT', array( 
-        'type' => 'checkbox' 
+    echo $this->Form->input('LEAVE_LIGHT', array(
+        'type' => 'checkbox'
         ,'label' => '全室内の消灯'
         ,'default' => ''
         ,'class' => 'leavecheck'
     ));
-    
+
     /**
      * 表示項目名：自分用、最終退室用、その他
      * DB項目名　：LEAVE_KEY
@@ -272,13 +272,13 @@
     echo '<p style="margin-top:15px;"><label>使用した鍵</label>';
     echo '<div class = "input radio">';
     $options = array('1' => '最終退室用', '2' => '自分用', '3' => 'その他');
-    $attributes = array('legend' => false , 'onClick' => 'changeDisabled()' 
+    $attributes = array('legend' => false , 'onClick' => 'changeDisabled()'
                         ,'default' => 1, 'class' => false, 'separator'=>'<br>'
                         ,'required' => false);
     echo $this->Form->radio('LEAVE_KEY', $options, $attributes);
     echo $this->Form->error('LEAVE_KEY', '必ず選択してください。');
     echo '</div>';
-    
+
     /**
      * 表示項目名：なし
      * DB項目名　：LEAVE_COMMENT
@@ -293,7 +293,7 @@
         ,'maxLength' => 100
     ));
     echo '</p>';
-    
+
     /**
      * 表示項目名：管理者チェック
      * DB項目名　：MANAGER_CHECK
@@ -308,7 +308,7 @@
         ,'class' => ''
     ));
     echo '</p>';
-    
+
     /**
      * 表示項目名：保存
      * DB項目名　：なし
@@ -318,10 +318,10 @@
     echo '<p style="margin-top:20px;margin-bottom:30px;">';
     echo $this->Form->button('<span class="glyphicon glyphicon-pencil"></span>　保存　', array('name' => 'save', 'class' => 'btn btn-success btn-block btn-lg'));
     echo '</p>';
-    
+
     /**
      * FormHelperの終了
      */
-    echo $this->Form->end(); 
+    echo $this->Form->end();
 
 ?>


### PR DESCRIPTION
# 残issueへの対応を実施
## Enhancement
#1 入退室者の一覧表示
## Bug Fix
#7 管理機能　：　詳細画面の印刷機能で当日分しか出力できない
## Other
- 出退勤保存のバリデーション前に前後空白除去する処理を追加
- README.mdにソフトウェアのバージョンを追記
## Comment

出退情報一覧のコントロールは微妙・・。View Helperあたりにロジックを映した方が良いかと。
エディターのせいでタブが半角空白に自動変換されるので、diffで変更だらけになってしまった。。
